### PR TITLE
Add docker_ruby_version input

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, members of
+# @rewindio/codeowners will be requested for review when someone
+# opens a pull request.
+*       @rewindio/devops

--- a/.github/workflows/pack-and-deploy-appversion.yml
+++ b/.github/workflows/pack-and-deploy-appversion.yml
@@ -16,6 +16,11 @@ on:
         description: "The Elastic Beanstalk version label"
         required: true
         type: string
+      docker_ruby_version:
+        description: "The version of Ruby to be used by the job container"
+        default: "2.6.8"
+        required: false
+        type: "string"
     secrets:
       EB_AWS_ACCESS_KEY_ID:
         required: true
@@ -29,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rewindio/docker-amazonlinux2-ruby:2.6.8
+      image: rewindio/docker-amazonlinux2-ruby:${{ inputs.docker_ruby_version }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/preprocess-environment.yml
+++ b/.github/workflows/preprocess-environment.yml
@@ -2,6 +2,12 @@ name: Set-up ElasticBeanstalk Extensions
 
 on:
   workflow_call:
+    inputs:
+      docker_ruby_version:
+        description: "The version of Ruby to be used by the job container"
+        default: "2.6.8"
+        required: false
+        type: "string"
     secrets:
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM:
         required: true
@@ -17,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: rewindio/docker-amazonlinux2-ruby:2.6.8
+      image: rewindio/docker-amazonlinux2-ruby:${{ inputs.docker_ruby_version }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
As the title says. Not all of our Rails repositories use the same version of Ruby, thus the need for a ruby_version input.