### PR TITLE
Add automated tagging

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,22 @@
+name: tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The branch to tag"
+        required: true
+      tag:
+        description: "The tag name to give. Should begin with 'v' and have a semver."
+        required: true
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Tag branch
+        run: git tag ${{ github.event.inputs.tag }} ${{ github.event.inputs.branch }}
+      - name: Share tag
+        run: git push --tags


### PR DESCRIPTION
Since we don't want releases here necessarily (don't need/want to publish to the GitHub Actions Marketplace) and don't tag on every push to main, I set up a workflow trigger based flow.