### PR TITLE
Bundle without dev,test, integration gems

### DIFF
--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           path: |
             vendor/cache
-            vendor/bundle
           # Note: 'Gemfile.lock' does not have a suffix, therefore we do not use {0}.{1}.lock
           key: ${{ runner.os }}-bundle-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
           restore-keys: |
@@ -90,13 +89,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-platform-${{ github.sha }}
 
-      - name: bundle install
+      - name: bundle package
         if: steps.bundle-cache.outputs.cache-hit != 'true'
         env:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle install --jobs 4 --retry 3
+          bundle package --no-install --jobs 4 --retry 3
           bundle clean --force
 
       # Pre-process the Beanstalk extensions and hooks
@@ -144,7 +143,6 @@ jobs:
         with:
           path: |
             vendor/cache
-            vendor/bundle
           key: ${{ runner.os }}-bundle-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
           restore-keys: |
             ${{ runner.os }}-bundle-

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -15,12 +15,14 @@ on:
         type: "string"
       eb_ext_branch:
         description: "The Elasticbeanstalk Extension branch to use"
-        required: true
+        required: false
         default: "main"
+        type: "string"
       eb_hook_branch:
         description: "The Elasticbeanstalk Hook branch to use"
-        required: true
+        required: false
         default: "main"
+        type: "string"
 
     secrets:
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM:

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           path: |
             vendor/cache
+            .bundle/config
           # Note: 'Gemfile.lock' does not have a suffix, therefore we do not use {0}.{1}.lock
           key: ${{ runner.os }}-bundle-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
           restore-keys: |
@@ -144,6 +145,7 @@ jobs:
         with:
           path: |
             vendor/cache
+            .bundle/config
           key: ${{ runner.os }}-bundle-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
           restore-keys: |
             ${{ runner.os }}-bundle-

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -97,6 +97,7 @@ jobs:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
+          bundle config list
           bundle cache --no-install
           bundle clean --force
 

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -51,12 +51,11 @@ jobs:
       - name: Configure bundler
         run: |
           mkdir -p vendor/bundle
-          mkdir -p vendor/cache
           bundle config set --local path vendor/bundle
-          bundle config set --local cache vendor/cache
-          bundle config set --local jobs 3
-          bundle config set --local retry 6
           bundle config set --local without 'test development integration'
+          bundle config set --local clean 'true'
+          bundle config set --local jobs 4
+          bundle config set --local retry 3
           bundle config set --local gemfile Gemfile${{ inputs.gemfile_suffix }}
 
       - name: bundle cache
@@ -65,11 +64,11 @@ jobs:
         with:
           path: |
             vendor/cache
-            .bundle/config
+            vendor/bundle
           # Note: 'Gemfile.lock' does not have a suffix, therefore we do not use {0}.{1}.lock
-          key: ${{ runner.os }}-bundle-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
+          key: ${{ runner.os }}-bundle-cache-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
           restore-keys: |
-            ${{ runner.os }}-bundle-
+            ${{ runner.os }}-bundle-cache-
 
       # Extensions caches need to be per commit because the extensions can change
       # without the underlying requirements.yml file changing
@@ -92,13 +91,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-platform-${{ github.sha }}
 
-      - name: bundle package
+      - name: bundle install
         if: steps.bundle-cache.outputs.cache-hit != 'true'
         env:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle cache --no-install
+          bundle install
 
       # Pre-process the Beanstalk extensions and hooks
       # We always want to do this in case an extension changes in the extensions/hooks repos
@@ -145,10 +144,10 @@ jobs:
         with:
           path: |
             vendor/cache
-            .bundle/config
-          key: ${{ runner.os }}-bundle-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
+            vendor/bundle
+          key: ${{ runner.os }}-bundle-cache-${{ hashFiles(format('**/{0}{1}.lock', 'Gemfile', inputs.gemfile_suffix )) }}
           restore-keys: |
-            ${{ runner.os }}-bundle-
+            ${{ runner.os }}-bundle-cache-
 
       - name: extensions cache
         uses: actions/cache@v2

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -54,7 +54,9 @@ jobs:
           mkdir -p vendor/cache
           bundle config set --local path vendor/bundle
           bundle config set --local cache vendor/cache
-          bundle config set without 'test development integration'
+          bundle config set --local jobs 3
+          bundle config set --local retry 6
+          bundle config set --local without 'test development integration'
           bundle config set --local gemfile Gemfile${{ inputs.gemfile_suffix }}
 
       - name: bundle cache
@@ -95,7 +97,7 @@ jobs:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle package --no-install
+          bundle cache --no-install
           bundle clean --force
 
       # Pre-process the Beanstalk extensions and hooks

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -13,6 +13,14 @@ on:
         default: ""
         required: false
         type: "string"
+     eb_ext_branch:
+        description: "The Elasticbeanstalk Extension branch to use"
+        required: true
+        default: "main"
+      eb_hook_branch:
+        description: "The Elasticbeanstalk Hook branch to use"
+        required: true
+        default: "main"
 
     secrets:
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM:
@@ -41,7 +49,9 @@ jobs:
       - name: Configure bundler
         run: |
           mkdir -p vendor/bundle
+          mkdir -p vendor/cache
           bundle config set --local path vendor/bundle
+          bundle config set --local cache vendor/cache
           bundle config set --local gemfile Gemfile${{ inputs.gemfile_suffix }}
 
       - name: bundle cache
@@ -83,7 +93,7 @@ jobs:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle install --jobs 4 --retry 3
+          bundle install --without test development integration --jobs 4 --retry 3
           bundle clean --force
 
       # Pre-process the Beanstalk extensions and hooks
@@ -92,6 +102,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rewindio/eb-extensions
+          ref: ${{ github.event.inputs.eb_ext_branch }}
           token: ${{ secrets.CONTAINER_REGISTRY_PAT }}
           path: tmp/eb-extensions
 
@@ -99,6 +110,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rewindio/eb-platform-hooks
+          ref: ${{ github.event.inputs.eb_hook_branch }}
           token: ${{ secrets.CONTAINER_REGISTRY_PAT }}
           path: tmp/eb-platform-hooks
 

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -97,7 +97,6 @@ jobs:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle config list
           bundle cache --no-install
 
       # Pre-process the Beanstalk extensions and hooks

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -13,7 +13,7 @@ on:
         default: ""
         required: false
         type: "string"
-     eb_ext_branch:
+      eb_ext_branch:
         description: "The Elasticbeanstalk Extension branch to use"
         required: true
         default: "main"

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -99,7 +99,6 @@ jobs:
         run: |
           bundle config list
           bundle cache --no-install
-          bundle clean --force
 
       # Pre-process the Beanstalk extensions and hooks
       # We always want to do this in case an extension changes in the extensions/hooks repos

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -13,16 +13,6 @@ on:
         default: ""
         required: false
         type: "string"
-      eb_ext_branch:
-        description: "The Elasticbeanstalk Extension branch to use"
-        required: false
-        default: "main"
-        type: "string"
-      eb_hook_branch:
-        description: "The Elasticbeanstalk Hook branch to use"
-        required: false
-        default: "main"
-        type: "string"
 
     secrets:
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM:
@@ -105,7 +95,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rewindio/eb-extensions
-          ref: ${{ github.event.inputs.eb_ext_branch }}
           token: ${{ secrets.CONTAINER_REGISTRY_PAT }}
           path: tmp/eb-extensions
 
@@ -113,7 +102,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rewindio/eb-platform-hooks
-          ref: ${{ github.event.inputs.eb_hook_branch }}
           token: ${{ secrets.CONTAINER_REGISTRY_PAT }}
           path: tmp/eb-platform-hooks
 

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -54,6 +54,7 @@ jobs:
           mkdir -p vendor/cache
           bundle config set --local path vendor/bundle
           bundle config set --local cache vendor/cache
+          bundle config set without 'test development integration'
           bundle config set --local gemfile Gemfile${{ inputs.gemfile_suffix }}
 
       - name: bundle cache
@@ -95,7 +96,7 @@ jobs:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle install --without test development integration --jobs 4 --retry 3
+          bundle install --jobs 4 --retry 3
           bundle clean --force
 
       # Pre-process the Beanstalk extensions and hooks

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -95,7 +95,7 @@ jobs:
           BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
         run: |
-          bundle package --no-install --jobs 4 --retry 3
+          bundle package --no-install
           bundle clean --force
 
       # Pre-process the Beanstalk extensions and hooks

--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Set commit title
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
         continue-on-error: true
-        run: |
-          COMMIT_TITLE="$(echo '''${{ github.event.head_commit.message }}''' | head -n 1)"
-          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
+        # We take the first line (%s) from the git log and then escape out any single quotes
+        # https://stackoverflow.com/a/24247870
+        run: echo COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s) >> $GITHUB_ENV
 
       - name: Notify Slack on Success
         uses: ravsamhq/notify-slack-action@v1

--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -79,74 +79,74 @@ jobs:
           wait_for_environment_recovery: 60
           max_backoff_retries: 13
 
-      # - name: Set commit title
-      #   # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      #   continue-on-error: true
-      #   run: |
-      #     COMMIT_TITLE="$(echo '''${{ github.event.head_commit.message }}''' | head -n 1)"
-      #     echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
+      - name: Set commit title
+        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+        continue-on-error: true
+        run: |
+          COMMIT_TITLE="$(echo '''${{ github.event.head_commit.message }}''' | head -n 1)"
+          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
 
-      # - name: Notify Slack on Success
-      #   uses: ravsamhq/notify-slack-action@v1
-      #   if: always()
-      #   with:
-      #     status: ${{ job.status }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
-      #     message_format: >
-      #       ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
-      #     footer: '<{repo_url}|{repo}>'
-      #     notify_when: 'success'
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_SUCCESS_SLACK_WEBHOOK_URL }}
+      - name: Notify Slack on Success
+        uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
+          message_format: >
+            ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
+          footer: '<{repo_url}|{repo}>'
+          notify_when: 'success'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_SUCCESS_SLACK_WEBHOOK_URL }}
 
-      # - name: Notify Slack on Failure
-      #   uses: ravsamhq/notify-slack-action@v1
-      #   if: always()
-      #   with:
-      #     status: ${{ job.status }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
-      #     message_format: >
-      #       ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
-      #     footer: '<{repo_url}|{repo}>'
-      #     notify_when: 'failure'
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_FAILURES_SLACK_WEBHOOK_URL }}
+      - name: Notify Slack on Failure
+        uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
+          message_format: >
+            ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
+          footer: '<{repo_url}|{repo}>'
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_FAILURES_SLACK_WEBHOOK_URL }}
 
-      # - name: Find Slack user
-      #   if: failure()
-      #   id: find-slack-user
-      #   uses: scribd/find-slack-user-action@v1
-      #   with:
-      #     include-at-symbol: true
-      #     slack-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
+      - name: Find Slack user
+        if: failure()
+        id: find-slack-user
+        uses: scribd/find-slack-user-action@v1
+        with:
+          include-at-symbol: true
+          slack-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
 
-      # - name: Send a Slack DM to the user linking the failure
-      #   if: failure()
-      #   uses: archive/github-actions-slack@v2.2.1
-      #   with:
-      #     slack-function: send-message
-      #     slack-bot-user-oauth-access-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
-      #     slack-channel: "${{ steps.find-slack-user.outputs.username }}"
-      #     slack-text: |
-      #       <@${{ steps.find-slack-user.outputs.member-id }}>: <${{ env.RUN_URL }}|${{ env.COMMIT_TITLE }}> has failed.
-      #   env:
-      #     RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: Send a Slack DM to the user linking the failure
+        if: failure()
+        uses: archive/github-actions-slack@v2.2.1
+        with:
+          slack-function: send-message
+          slack-bot-user-oauth-access-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
+          slack-channel: "${{ steps.find-slack-user.outputs.username }}"
+          slack-text: |
+            <@${{ steps.find-slack-user.outputs.member-id }}>: <${{ env.RUN_URL }}|${{ env.COMMIT_TITLE }}> has failed.
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      # - name: Mark Release in HoneyBadger
-      #   if: inputs.notify_honeybadger == true
-      #   uses: honeybadger-io/github-notify-deploy-action@v1
-      #   with:
-      #     api_key: ${{ secrets.HONEYBADGER_JS_API_KEY }}
-      #     environment: ${{ matrix.env }}
+      - name: Mark Release in HoneyBadger
+        if: inputs.notify_honeybadger == true
+        uses: honeybadger-io/github-notify-deploy-action@v1
+        with:
+          api_key: ${{ secrets.HONEYBADGER_JS_API_KEY }}
+          environment: ${{ matrix.env }}
 
-      # - name: Mark Release in New Relic
-      #   if: inputs.notify_new_relic == true
-      #   uses: newrelic/deployment-marker-action@v1
-      #   with:
-      #     apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-      #     accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-      #     applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
-      #     revision: "${{ github.ref }}-${{ github.sha }}"
-      #     user: "${{ github.actor }}"
+      - name: Mark Release in New Relic
+        if: inputs.notify_new_relic == true
+        uses: newrelic/deployment-marker-action@v1
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+          revision: "${{ github.ref }}-${{ github.sha }}"
+          user: "${{ github.actor }}"

--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -78,74 +78,74 @@ jobs:
           wait_for_deployment: true
           wait_for_environment_recovery: 60
 
-      - name: Set commit title
-        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-        continue-on-error: true
-        run: |
-          COMMIT_TITLE="$(echo '''${{ github.event.head_commit.message }}''' | head -n 1)"
-          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
+      # - name: Set commit title
+      #   # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+      #   continue-on-error: true
+      #   run: |
+      #     COMMIT_TITLE="$(echo '''${{ github.event.head_commit.message }}''' | head -n 1)"
+      #     echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
 
-      - name: Notify Slack on Success
-        uses: ravsamhq/notify-slack-action@v1
-        if: always()
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
-          message_format: >
-            ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
-          footer: '<{repo_url}|{repo}>'
-          notify_when: 'success'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_SUCCESS_SLACK_WEBHOOK_URL }}
+      # - name: Notify Slack on Success
+      #   uses: ravsamhq/notify-slack-action@v1
+      #   if: always()
+      #   with:
+      #     status: ${{ job.status }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
+      #     message_format: >
+      #       ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
+      #     footer: '<{repo_url}|{repo}>'
+      #     notify_when: 'success'
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_SUCCESS_SLACK_WEBHOOK_URL }}
 
-      - name: Notify Slack on Failure
-        uses: ravsamhq/notify-slack-action@v1
-        if: always()
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
-          message_format: >
-            ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
-          footer: '<{repo_url}|{repo}>'
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_FAILURES_SLACK_WEBHOOK_URL }}
+      # - name: Notify Slack on Failure
+      #   uses: ravsamhq/notify-slack-action@v1
+      #   if: always()
+      #   with:
+      #     status: ${{ job.status }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     notification_title: '{emoji} <{run_url}|{workflow}> to ${{ matrix.app }} in ${{ matrix.region }} (${{ matrix.env }}) has {status_message}'
+      #     message_format: >
+      #       ${{ github.actor }} pushed <{commit_url}|${{ env.COMMIT_TITLE }}>
+      #     footer: '<{repo_url}|{repo}>'
+      #     notify_when: 'failure'
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_FAILURES_SLACK_WEBHOOK_URL }}
 
-      - name: Find Slack user
-        if: failure()
-        id: find-slack-user
-        uses: scribd/find-slack-user-action@v1
-        with:
-          include-at-symbol: true
-          slack-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
+      # - name: Find Slack user
+      #   if: failure()
+      #   id: find-slack-user
+      #   uses: scribd/find-slack-user-action@v1
+      #   with:
+      #     include-at-symbol: true
+      #     slack-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
 
-      - name: Send a Slack DM to the user linking the failure
-        if: failure()
-        uses: archive/github-actions-slack@v2.2.1
-        with:
-          slack-function: send-message
-          slack-bot-user-oauth-access-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
-          slack-channel: "${{ steps.find-slack-user.outputs.username }}"
-          slack-text: |
-            <@${{ steps.find-slack-user.outputs.member-id }}>: <${{ env.RUN_URL }}|${{ env.COMMIT_TITLE }}> has failed.
-        env:
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # - name: Send a Slack DM to the user linking the failure
+      #   if: failure()
+      #   uses: archive/github-actions-slack@v2.2.1
+      #   with:
+      #     slack-function: send-message
+      #     slack-bot-user-oauth-access-token: ${{ secrets.LOOKUP_USER_EMAIL_SLACK_TOKEN }}
+      #     slack-channel: "${{ steps.find-slack-user.outputs.username }}"
+      #     slack-text: |
+      #       <@${{ steps.find-slack-user.outputs.member-id }}>: <${{ env.RUN_URL }}|${{ env.COMMIT_TITLE }}> has failed.
+      #   env:
+      #     RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Mark Release in HoneyBadger
-        if: inputs.notify_honeybadger == true
-        uses: honeybadger-io/github-notify-deploy-action@v1
-        with:
-          api_key: ${{ secrets.HONEYBADGER_JS_API_KEY }}
-          environment: ${{ matrix.env }}
+      # - name: Mark Release in HoneyBadger
+      #   if: inputs.notify_honeybadger == true
+      #   uses: honeybadger-io/github-notify-deploy-action@v1
+      #   with:
+      #     api_key: ${{ secrets.HONEYBADGER_JS_API_KEY }}
+      #     environment: ${{ matrix.env }}
 
-      - name: Mark Release in New Relic
-        if: inputs.notify_new_relic == true
-        uses: newrelic/deployment-marker-action@v1
-        with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
-          revision: "${{ github.ref }}-${{ github.sha }}"
-          user: "${{ github.actor }}"
+      # - name: Mark Release in New Relic
+      #   if: inputs.notify_new_relic == true
+      #   uses: newrelic/deployment-marker-action@v1
+      #   with:
+      #     apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+      #     accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+      #     applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+      #     revision: "${{ github.ref }}-${{ github.sha }}"
+      #     user: "${{ github.actor }}"


### PR DESCRIPTION
I was having issues with my safety-zone deploys before the holidays.  I was trying to have it use this action but instead had lots of strange errors related to gems that shouldn't be installed in AWS.

Took a deep dive then and noticed bundle without wasn't set and gems like rubocop etc. were in the zip file.

Pulled this from a rewind-worker zip deploy
![image](https://user-images.githubusercontent.com/32844597/149222170-eccd6eb7-78ce-4460-848b-301b431b4b7e.png)

This fixes that and in order to start fresh, I needed to invalidate the bundle-cache on the github side.  You can't actually do that though.. it auto purges after 7 days of inactivity or you can rename the cache key which is what the interwebs suggest - so I did that.

Bonus: the zip files should get a little bit smaller too.

Also moved some of the flags up to the local bundle config too for consistency.

Tested out in https://github.com/rewindio/the-safety-zone/actions/runs/1689564839

