### PR TITLE
Add optional ref inputs for eb-extensions and eb-platform-hooks

### DIFF
--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -13,6 +13,16 @@ on:
         default: ""
         required: false
         type: "string"
+      eb_extensions_ref:
+        description: "The branch in rewindio/eb-extensions to be checked-out"
+        default: ""
+        required: false
+        type: "string"
+      eb_platform_hooks_ref:
+        description: "The branch in rewindio/eb-platform-hooks to be checked-out"
+        default: ""
+        required: false
+        type: "string"
 
     secrets:
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM:
@@ -92,6 +102,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rewindio/eb-extensions
+          ref: ${{ inputs.eb_extensions_ref }}
           token: ${{ secrets.CONTAINER_REGISTRY_PAT }}
           path: tmp/eb-extensions
 
@@ -99,6 +110,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rewindio/eb-platform-hooks
+          ref: ${{ inputs.eb_platform_hooks_ref }}
           token: ${{ secrets.CONTAINER_REGISTRY_PAT }}
           path: tmp/eb-platform-hooks
 


### PR DESCRIPTION
As the title says. This is to allow for easier testing of eb-extensions or eb-platform-hooks