### PR TITLE
Add optional "set Procfile" step

### DIFF
--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -23,8 +23,8 @@ on:
         default: ""
         required: false
         type: "string"
-      custom_procfile_dir:
-        description: "The directory of a Procfile to be moved to the base directory of the application zip. Should begin with './' (from application base directory)"
+      custom_procfile_path:
+        description: "The file path of a Procfile to be moved to the base directory of the application zip. Should begin with './' (from application base directory)"
         default: ""
         required: false
         type: "string"
@@ -173,9 +173,9 @@ jobs:
             ${{ runner.os }}-platform-${{ github.sha }}
 
       - name: set Procfile
-        if: inputs.custom_procfile_dir != ''
+        if: inputs.custom_procfile_path != ''
         run: |
-          mv ${{ inputs.custom_procfile_dir }} ./Procfile
+          mv ${{ inputs.custom_procfile_path }} ./Procfile
 
       - name: Create zip
         run:

--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -23,6 +23,11 @@ on:
         default: ""
         required: false
         type: "string"
+      custom_procfile_dir:
+        description: "The directory of a Procfile to be moved to the base directory of the application zip. Should begin with './' (from application base directory)"
+        default: ""
+        required: false
+        type: "string"
 
     secrets:
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM:
@@ -166,6 +171,11 @@ jobs:
           key: ${{ runner.os }}-extensions-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-platform-${{ github.sha }}
+
+      - name: set Procfile
+        if: inputs.custom_procfile_dir != ''
+        run: |
+          mv ${{ inputs.custom_procfile_dir }} ./Procfile
 
       - name: Create zip
         run:


### PR DESCRIPTION
As the title says. This will allow for projects to have multiple Procfiles and for the deployment workflows that call compile-artifact to set the Procfile in CI/CD.