### PR TITLE
bump actions/cache v2 -> v3

### DIFF
--- a/.github/workflows/compile-artifact.yml
+++ b/.github/workflows/compile-artifact.yml
@@ -59,7 +59,7 @@ jobs:
           bundle config set --local gemfile Gemfile${{ inputs.gemfile_suffix }}
 
       - name: bundle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: bundle-cache
         with:
           path: |
@@ -74,7 +74,7 @@ jobs:
       # without the underlying requirements.yml file changing
       # We are really only using the cache to pass to the next job
       - name: extensions cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: extensions-cache
         with:
           path: .ebextensions
@@ -83,7 +83,7 @@ jobs:
             ${{ runner.os }}-extensions-${{ github.sha }}
 
       - name: hooks cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: hooks-cache
         with:
           path: .platform
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: bundle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: bundle-cache
         with:
           path: |
@@ -150,7 +150,7 @@ jobs:
             ${{ runner.os }}-bundle-cache-
 
       - name: extensions cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: extensions-cache
         with:
           path: .ebextensions
@@ -159,7 +159,7 @@ jobs:
             ${{ runner.os }}-extensions-${{ github.sha }}
 
       - name: hooks cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: hooks-cache
         with:
           path: .platform


### PR DESCRIPTION
bump actions cache from v2 -> v3.

this should hopefully resolve https://github.com/rewindio/ultron/runs/6231016178?check_suite_focus=true

problem: v2 only supports node12. v3 recently added support for node16.